### PR TITLE
change mds schema from dev to master

### DIFF
--- a/validator.py
+++ b/validator.py
@@ -4,8 +4,8 @@ from jsonschema import Draft4Validator
 import requests
 import pandas as pd
 
-MDS_SCHEMA_PATH ="https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/dev/provider/"
-
+MDS_SCHEMA_PATH = "https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/provider/"
+PROVIDERS_INFO_PATH = "https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/providers.csv"
 
 
 class Error(Exception):
@@ -27,7 +27,7 @@ class MDSProviderApi():
     """
     
     def _get_mds_url(self):
-        df = pd.read_csv('https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/dev/providers.csv')
+        df = pd.read_csv(PROVIDERS_INFO_PATH)
         providers = df.to_dict(orient='records')
         for provider in providers:
             if provider['provider_name'].lower() == self.name.lower():


### PR DESCRIPTION
the mds validator script currently pulls the mds schema from the dev branch of https://github.com/CityOfLosAngeles/mobility-data-specification/. i don't think this is intended, because the dev branch is used to prepare for the next release. 

our team's API was failing against the mds-validator because of this breaking change made to dev: https://github.com/CityOfLosAngeles/mobility-data-specification/pull/179

i don't think this was intended behavior.