### PR TITLE
Refactor validate.py to accept manually specified MDS API URLs.

### DIFF
--- a/validator.py
+++ b/validator.py
@@ -21,29 +21,29 @@ class ProviderNotFoundError(Error):
         self.expression = expression 
         self.message = message
 
+def GetMdsUrl(provider_name):
+    df = pd.read_csv(PROVIDERS_INFO_PATH)
+    providers = df.to_dict(orient='records')
+    for provider in providers:
+        if provider['provider_name'].lower() == provider_name.lower():
+            return provider['mds_api_url']
+    names = str([x['provider_name'] for x in providers])
+    msg = "Provider {} not in list of providers {}".format(provider_name, names)
+    raise ProviderNotFoundError("ProviderNotFoundError", msg)
+
+def ComposeHeader(provider_name, token):
+    if provider_name.lower() == 'bird':
+        auth = 'Bird ' + token
+        header = {'Authorization': auth, 'APP-Version': '3.0.0'}
+    else:
+        auth = 'Bearer ' + token
+        header = {'Authorization': auth}
+    return header
+
 class MDSProviderApi(): 
     """
     Class representing an MDS provider API
     """
-    
-    def _get_mds_url(self):
-        df = pd.read_csv(PROVIDERS_INFO_PATH)
-        providers = df.to_dict(orient='records')
-        for provider in providers:
-            if provider['provider_name'].lower() == self.name.lower():
-                return provider['mds_api_url']
-        names = str([x['provider_name'] for x in providers])
-        msg = "Provider {} not in list of providers {}".format(self.name, names)
-        raise ProviderNotFoundError("ProviderNotFoundError", msg)
-
-    def _compose_header(self):
-        if self.name.lower() == 'bird':
-            auth = 'Bird ' + self.token
-            header = {'Authorization': auth, 'APP-Version': '3.0.0'}
-        else:
-            auth = 'Bearer ' + self.token
-            header = {'Authorization': auth}
-        return header
     
     def validate_trips(self): 
         """
@@ -52,7 +52,7 @@ class MDSProviderApi():
         r = requests.get(MDS_SCHEMA_PATH + "trips.json")
         schema = r.json()
         v = Draft4Validator(schema)
-        r  = requests.get(self._get_mds_url() + self.post_fix + '/trips', headers = self._compose_header())  
+        r  = requests.get(self.mds_url + '/trips', headers = self.headers)
         json = r.json()
         try: 
             jsonschema.validate(json,schema)
@@ -63,7 +63,7 @@ class MDSProviderApi():
                 for suberror in sorted(error.context, key=lambda e: e.schema_path):
                     print(list(suberror.schema_path), suberror.message, sep=", ")
             return False
-        print("Validated Trips for {}".format(self.name))
+        print("Validated Trips for {}".format(self.mds_url))
         return True
 
     def validate_status_changes(self):
@@ -74,7 +74,7 @@ class MDSProviderApi():
         schema = r.json()
         v = Draft4Validator(schema)
 
-        r  = requests.get(self._get_mds_url() + self.post_fix + '/status_changes', headers = self._compose_header())
+        r  = requests.get(self.mds_url + '/status_changes', headers = self.headers)
 
         json = r.json()
         try: 
@@ -86,7 +86,7 @@ class MDSProviderApi():
                 for suberror in sorted(error.context, key=lambda e: e.schema_path):
                     print(list(suberror.schema_path), suberror.message, sep=", ")
             return False
-        print("Validated Status Changes for {}".format(self.name))
+        print("Validated Status Changes for {}".format(self.mds_url))
         return True 
 
     def test_query_params(self):
@@ -94,33 +94,40 @@ class MDSProviderApi():
         Tests if you can pass query params to the APIs and get back data
         """
         pass
-    def __init__(self, name, token, post_fix):
-        self.name = name
-        self.token = token
-        self.post_fix = post_fix
-        self.header = {'Authorization': "Bearer " + self.token}
+    def __init__(self, mds_url, headers):
+        self.mds_url = mds_url
+        self.headers = headers
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Provide an MDS API to validate')
-    parser.add_argument("--provider-name",type=str,
-                        help="Name of the Provider that you are attempt to validate")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--provider-name",type=str,
+                       help="Name of the Provider that you are attempt to validate")
+    group.add_argument("--mds-url",type=str,
+                       help="Manual specification of MDS API to validate")
 
     parser.add_argument("--token",type=str,
-                        help="Bearer Token for the provider that you are attempting to validate")
+                        help="Bearer Token for the provider that you are attempting to validate",
+                        required=True)
     parser.add_argument("--postfix", type=str,
                         help="if it exists, the post_fix (ie, city or version or both) from the MDS base url in providers.csv")
     
-
     parser.add_argument('--status-changes', dest='status_change', action='store_true')
     parser.add_argument('--trips', dest='trips', action='store_true')
     parser.set_defaults(status_change=False)
     parser.set_defaults(trips=False)
     args = parser.parse_args()
-    if args.postfix: 
-        api = MDSProviderApi(args.provider_name,args.token, args.postfix)
-    else: 
-        api = MDSProviderApi(args.provider_name, args.token, '')
-    print("Attempting to validate {}".format(api.name))
+
+    mds_url = args.mds_url
+    if args.provider_name:
+        mds_url = GetMdsUrl(args.provider_name)
+        headers = ComposeHeader(args.provider_name, args.token)
+    if args.postfix:
+        mds_url += args.postfix
+        headers = ComposeHeader("", args.token)
+
+    api = MDSProviderApi(mds_url, headers)
+    print("Attempting to validate {}".format(mds_url))
     if args.trips:
         api.validate_trips()
     elif args.status_change:


### PR DESCRIPTION
This allows for testing against in-devleopment MDS implementations
without resorting to modifying upstream providers.csv.

Notable changes:
  - Introduce --mds-url, a mutually exclusive argument to
    --provider-name that allows for manually specifying the MDS API URL
  - Set argparse's required flag where necessary to print command usage
    instead of throwing Python exceptions
  - Pull out _get_mds_url() and _compose_header() into global functions
    to permit easier reuse of MDSProviderApi class
  - Use the MDS API URL for log statements